### PR TITLE
Feat/906 include missing filepaths

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,262 +1,266 @@
--   id: check-column-desc-are-same
-    name: Check column descriptions are same
-    description: Check the models have same descriptions for same column names.
-    entry: check-column-desc-are-same
-    language: python
-    files: '.*\.(yml|yaml)$'
--   id: check-column-name-contract
-    name: Check column name contract
-    description: Check column name abides to contract.
-    entry: check-column-name-contract
-    language: python
-    types: [sql]
--   id: check-macro-has-description
-    name: Check the macro has description
-    description: Ensures that the macro has description in properties file.
-    entry: check-macro-has-description
-    language: python
-    types_or: [yaml, sql]
-    require_serial: true # because we need to process yaml and sql
--   id: check-macro-arguments-have-desc
-    name: Check the macro arguments have description
-    description: Ensures that the macro has arguments with descriptions in properties file.
-    entry: check-macro-arguments-have-desc
-    language: python
-    types_or: [yaml, sql]
-    require_serial: true # because we need to process yaml and sql
--   id: check-model-columns-have-desc
-    name: Check the model columns have description
-    description: Ensures that the model has columns with descriptions in properties file.
-    entry: check-model-columns-have-desc
-    language: python
-    types_or: [yaml, sql]
-    require_serial: true # because we need to process yaml and sql
--   id: check-model-has-all-columns
-    name: Check the model has all columns in properties file
-    description: Ensures that all columns in database are specified in properties file.
-    entry: check-model-has-all-columns
-    language: python
-    types: [sql]
--   id: check-model-has-description
-    name: Check the model has description
-    description: Ensures that the model has description in properties file.
-    entry: check-model-has-description
-    language: python
-    types_or: [yaml, sql]
-    require_serial: true # because we need to process yaml and sql
--   id: check-model-has-meta-keys
-    name: Check the model has keys in the meta part
-    description: Ensures that the model has a list of valid meta keys.
-    entry: check-model-has-meta-keys
-    language: python
-    types_or: [yaml, sql]
-    require_serial: true # because we need to process YAML and SQL
--   id: check-model-has-properties-file
-    name: Check the model has properties file
-    description: Ensures that the model has properties file (schema file).
-    entry: check-model-has-properties-file
-    language: python
-    types: [sql]
--   id: check-model-has-tests-by-group
-    name: Check the model has a number of tests from a group of tests.
-    description: Ensures that the model has a number of tests from a group of tests.
-    entry: check-model-has-tests-by-group
-    language: python
-    types: [sql]
--   id: check-model-has-tests-by-name
-    name: Check the model tests by a test name
-    description: Ensures that the model has a number of tests of a certain name (e.g. data, unique).
-    entry: check-model-has-tests-by-name
-    language: python
-    types: [sql]
--   id: check-model-has-tests-by-type
-    name: Check the model tests by a test type
-    description: Ensures that the model has a number of tests of a certain type (data, schema).
-    entry: check-model-has-tests-by-type
-    language: python
-    types: [sql]
--   id: check-model-has-tests
-    name: Check the model has a tests
-    description: Ensures that the model has a number of tests.
-    entry: check-model-has-tests
-    language: python
-    types: [sql]
--   id: check-model-name-contract
-    name: Check model name contract
-    description: Check model name abides to contract.
-    entry: check-model-name-contract
-    language: python
-    types: [sql]
--   id: check-model-parents-schema
-    name: Check parent models or sources are from certain schema
-    entry: check-model-parents-schema
-    language: python
-    types_or: [yaml]
--   id: check-model-parents-and-childs
-    name: Check the model has a parents/childs
-    description: Ensures the model has a specific number (max/min) of parents or/and childs.
-    entry: check-model-parents-and-childs
-    language: python
-    types: [sql]
--   id: check-model-tags
-    name: Check the model has valid tags
-    description: Ensures that the model has only valid tags from the provided list.
-    entry: check-model-tags
-    language: python
-    types: [sql]
--   id: check-script-has-no-table-name
-    name: Check the script has not table name
-    description: Ensures that the script is using only source or ref macro to specify the table name.
-    entry: check-script-has-no-table-name
-    language: python
-    types: [sql]
--   id: check-script-ref-and-source
-    name: Check the script has existing refs and sources
-    description: Ensures that the script contains only existing sources or macros.
-    entry: check-script-ref-and-source
-    language: python
-    types: [sql]
--   id: check-script-semicolon
-    name: Check the script does not contain a semicolon
-    description: Ensure that the script does not have a semicolon at the end of the file.
-    entry: check-script-semicolon
-    language: python
-    types: [sql]
--   id: check-source-childs
-    name: Check the source has a specific number (max/min) of childs.
-    description: Ensures the source has a specific number (max/min) of childs.
-    entry: check-source-childs
-    language: python
-    types: [sql]  
--   id: check-source-columns-have-desc
-    name: Check for source column descriptions
-    description: Ensures that the source has columns with descriptions in the properties file.
-    entry: check-source-columns-have-desc
-    language: python
-    types_or: [yaml]
--   id: check-source-has-all-columns
-    name: Check the source has all columns in the properties file
-    description: Ensures that all columns in the database are specified in the properties file.
-    entry: check-source-has-all-columns
-    language: python
-    types_or: [yaml]
--   id: check-source-table-has-description
-    name: Check the source table has description
-    description: Ensures that the source table has description in properties file.
-    entry: check-source-table-has-description
-    language: python
-    types_or: [yaml]
--   id: check-source-has-freshness
-    name: Check the source has the freshness
-    description: Ensures that the source has freshness options.
-    entry: check-source-has-freshness
-    language: python
-    types_or: [yaml]
--   id: check-source-has-loader
-    name: Check the source has loader option
-    description: Ensures that the source has loader option.
-    entry: check-source-has-loader
-    language: python
-    types_or: [yaml]
--   id: check-source-has-meta-keys
-    name: Check the source has keys in the meta part
-    description: Ensures that the source has a list of valid meta keys.
-    entry: check-source-has-meta-keys
-    language: python
-    types_or: [yaml]
--   id: check-source-has-tests-by-name
-    name: Check the source tests by test name
-    description: Ensures that the source has a number of tests of a certain name (e.g. data, unique).
-    entry: check-source-has-tests-by-name
-    language: python
-    types_or: [yaml]
--   id: check-source-has-tests-by-type
-    name: Check the source tests by test type
-    description: Ensures that the source has a number of tests of a certain type (data, schema).
-    entry: check-source-has-tests-by-type
-    language: python
-    types_or: [yaml]
--   id: check-source-has-tests
-    name: Check the source has tests
-    description: Ensures that the source has a number of tests.
-    entry: check-source-has-tests
-    language: python
-    types_or: [yaml]
--   id: check-source-tags
-    name: Check the source has valid tags
-    description: Ensures that the source has only valid tags from the provided list.
-    entry: check-source-tags
-    language: python
-    types_or: [yaml]
--   id: dbt-clean
-    name: dbt clean
-    description: Deletes all folders specified in the clean-targets.
-    entry: dbt-clean
-    language: python
-    pass_filenames: false
--   id: dbt-compile
-    name: dbt compile
-    description: Generates executable SQL from source model, test, and analysis files.
-    entry: dbt-compile
-    language: python
-    types: [sql]
-    require_serial: true
--   id: dbt-deps
-    name: dbt deps
-    description: Pulls the most recent version of the dependencies listed in your packages.yml.
-    entry: dbt-deps
-    language: python
-    pass_filenames: false
--   id: dbt-docs-generate
-    name: dbt docs generate
-    description: The command is responsible for generating your project's documentation website.
-    entry: dbt-docs-generate
-    language: python
-    pass_filenames: false
--   id: dbt-run
-    name: dbt run
-    description: Executes compiled sql model files.
-    entry: dbt-run
-    language: python
-    require_serial: true
-    types: [sql]
--   id: dbt-test
-    name: dbt test
-    description: Runs tests on data in deployed models.
-    entry: dbt-test
-    language: python
-    require_serial: true
-    types: [sql]
--   id: generate-missing-sources
-    name: Generate missing sources
-    description: If any source is missing this hook tries to create it.
-    entry: generate-missing-sources
-    language: python
-    types: [sql]
--   id: generate-model-properties-file
-    name: Generate model properties file
-    description: Generate model properties file if does not exists.
-    entry: generate-model-properties-file
-    language: python
-    types: [sql]
-    args: ["--properties-file", "/Users/tomsejr/Documents/03-Workspace/Private/jaffle_shop/{database}/{schema}/{name}.yml"]
-    require_serial: true
--   id: unify-column-description
-    name: Unify column description
-    description: Unify column descriptions across all models
-    entry: unify-column-description
-    language: python
-    files: '.*\.(yml|yaml)$'
-    require_serial: true
--   id: replace-script-table-names
-    name: Replace script table names
-    description: Replace table names with source or ref macros in the script.
-    entry: replace-script-table-names
-    language: python
-    types: [sql]
--   id: remove-script-semicolon
-    name: Remove script semicolon
-    description: Remove semicolon at the end of the script.
-    entry: remove-script-semicolon
-    language: python
-    types: [sql]
+- id: check-column-desc-are-same
+  name: Check column descriptions are same
+  description: Check the models have same descriptions for same column names.
+  entry: check-column-desc-are-same
+  language: python
+  files: '.*\.(yml|yaml)$'
+- id: check-column-name-contract
+  name: Check column name contract
+  description: Check column name abides to contract.
+  entry: check-column-name-contract
+  language: python
+  types: [sql, yaml]
+- id: check-macro-has-description
+  name: Check the macro has description
+  description: Ensures that the macro has description in properties file.
+  entry: check-macro-has-description
+  language: python
+  types_or: [yaml, sql]
+  require_serial: true # because we need to process yaml and sql
+- id: check-macro-arguments-have-desc
+  name: Check the macro arguments have description
+  description: Ensures that the macro has arguments with descriptions in properties file.
+  entry: check-macro-arguments-have-desc
+  language: python
+  types_or: [yaml, sql]
+  require_serial: true # because we need to process yaml and sql
+- id: check-model-columns-have-desc
+  name: Check the model columns have description
+  description: Ensures that the model has columns with descriptions in properties file.
+  entry: check-model-columns-have-desc
+  language: python
+  types_or: [yaml, sql]
+  require_serial: true # because we need to process yaml and sql
+- id: check-model-has-all-columns
+  name: Check the model has all columns in properties file
+  description: Ensures that all columns in database are specified in properties file.
+  entry: check-model-has-all-columns
+  language: python
+  types: [sql, yaml]
+- id: check-model-has-description
+  name: Check the model has description
+  description: Ensures that the model has description in properties file.
+  entry: check-model-has-description
+  language: python
+  types_or: [yaml, sql]
+  require_serial: true # because we need to process yaml and sql
+- id: check-model-has-meta-keys
+  name: Check the model has keys in the meta part
+  description: Ensures that the model has a list of valid meta keys.
+  entry: check-model-has-meta-keys
+  language: python
+  types_or: [yaml, sql]
+  require_serial: true # because we need to process YAML and SQL
+- id: check-model-has-properties-file
+  name: Check the model has properties file
+  description: Ensures that the model has properties file (schema file).
+  entry: check-model-has-properties-file
+  language: python
+  types: [sql, yaml]
+- id: check-model-has-tests-by-group
+  name: Check the model has a number of tests from a group of tests.
+  description: Ensures that the model has a number of tests from a group of tests.
+  entry: check-model-has-tests-by-group
+  language: python
+  types: [sql, yaml]
+- id: check-model-has-tests-by-name
+  name: Check the model tests by a test name
+  description: Ensures that the model has a number of tests of a certain name (e.g. data, unique).
+  entry: check-model-has-tests-by-name
+  language: python
+  types: [sql, yaml]
+- id: check-model-has-tests-by-type
+  name: Check the model tests by a test type
+  description: Ensures that the model has a number of tests of a certain type (data, schema).
+  entry: check-model-has-tests-by-type
+  language: python
+  types: [sql, yaml]
+- id: check-model-has-tests
+  name: Check the model has a tests
+  description: Ensures that the model has a number of tests.
+  entry: check-model-has-tests
+  language: python
+  types: [sql, yaml]
+- id: check-model-name-contract
+  name: Check model name contract
+  description: Check model name abides to contract.
+  entry: check-model-name-contract
+  language: python
+  types: [sql]
+- id: check-model-parents-schema
+  name: Check parent models or sources are from certain schema
+  entry: check-model-parents-schema
+  language: python
+  types_or: [yaml, sql]
+- id: check-model-parents-and-childs
+  name: Check the model has a parents/childs
+  description: Ensures the model has a specific number (max/min) of parents or/and childs.
+  entry: check-model-parents-and-childs
+  language: python
+  types: [sql, yaml]
+- id: check-model-tags
+  name: Check the model has valid tags
+  description: Ensures that the model has only valid tags from the provided list.
+  entry: check-model-tags
+  language: python
+  types: [sql, yaml]
+- id: check-script-has-no-table-name
+  name: Check the script has not table name
+  description: Ensures that the script is using only source or ref macro to specify the table name.
+  entry: check-script-has-no-table-name
+  language: python
+  types: [sql]
+- id: check-script-ref-and-source
+  name: Check the script has existing refs and sources
+  description: Ensures that the script contains only existing sources or macros.
+  entry: check-script-ref-and-source
+  language: python
+  types: [sql]
+- id: check-script-semicolon
+  name: Check the script does not contain a semicolon
+  description: Ensure that the script does not have a semicolon at the end of the file.
+  entry: check-script-semicolon
+  language: python
+  types: [sql]
+- id: check-source-childs
+  name: Check the source has a specific number (max/min) of childs.
+  description: Ensures the source has a specific number (max/min) of childs.
+  entry: check-source-childs
+  language: python
+  types: [sql]
+- id: check-source-columns-have-desc
+  name: Check for source column descriptions
+  description: Ensures that the source has columns with descriptions in the properties file.
+  entry: check-source-columns-have-desc
+  language: python
+  types_or: [yaml]
+- id: check-source-has-all-columns
+  name: Check the source has all columns in the properties file
+  description: Ensures that all columns in the database are specified in the properties file.
+  entry: check-source-has-all-columns
+  language: python
+  types_or: [yaml]
+- id: check-source-table-has-description
+  name: Check the source table has description
+  description: Ensures that the source table has description in properties file.
+  entry: check-source-table-has-description
+  language: python
+  types_or: [yaml]
+- id: check-source-has-freshness
+  name: Check the source has the freshness
+  description: Ensures that the source has freshness options.
+  entry: check-source-has-freshness
+  language: python
+  types_or: [yaml]
+- id: check-source-has-loader
+  name: Check the source has loader option
+  description: Ensures that the source has loader option.
+  entry: check-source-has-loader
+  language: python
+  types_or: [yaml]
+- id: check-source-has-meta-keys
+  name: Check the source has keys in the meta part
+  description: Ensures that the source has a list of valid meta keys.
+  entry: check-source-has-meta-keys
+  language: python
+  types_or: [yaml]
+- id: check-source-has-tests-by-name
+  name: Check the source tests by test name
+  description: Ensures that the source has a number of tests of a certain name (e.g. data, unique).
+  entry: check-source-has-tests-by-name
+  language: python
+  types_or: [yaml]
+- id: check-source-has-tests-by-type
+  name: Check the source tests by test type
+  description: Ensures that the source has a number of tests of a certain type (data, schema).
+  entry: check-source-has-tests-by-type
+  language: python
+  types_or: [yaml]
+- id: check-source-has-tests
+  name: Check the source has tests
+  description: Ensures that the source has a number of tests.
+  entry: check-source-has-tests
+  language: python
+  types_or: [yaml]
+- id: check-source-tags
+  name: Check the source has valid tags
+  description: Ensures that the source has only valid tags from the provided list.
+  entry: check-source-tags
+  language: python
+  types_or: [yaml]
+- id: dbt-clean
+  name: dbt clean
+  description: Deletes all folders specified in the clean-targets.
+  entry: dbt-clean
+  language: python
+  pass_filenames: false
+- id: dbt-compile
+  name: dbt compile
+  description: Generates executable SQL from source model, test, and analysis files.
+  entry: dbt-compile
+  language: python
+  types: [sql]
+  require_serial: true
+- id: dbt-deps
+  name: dbt deps
+  description: Pulls the most recent version of the dependencies listed in your packages.yml.
+  entry: dbt-deps
+  language: python
+  pass_filenames: false
+- id: dbt-docs-generate
+  name: dbt docs generate
+  description: The command is responsible for generating your project's documentation website.
+  entry: dbt-docs-generate
+  language: python
+  pass_filenames: false
+- id: dbt-run
+  name: dbt run
+  description: Executes compiled sql model files.
+  entry: dbt-run
+  language: python
+  require_serial: true
+  types: [sql]
+- id: dbt-test
+  name: dbt test
+  description: Runs tests on data in deployed models.
+  entry: dbt-test
+  language: python
+  require_serial: true
+  types: [sql]
+- id: generate-missing-sources
+  name: Generate missing sources
+  description: If any source is missing this hook tries to create it.
+  entry: generate-missing-sources
+  language: python
+  types: [sql]
+- id: generate-model-properties-file
+  name: Generate model properties file
+  description: Generate model properties file if does not exists.
+  entry: generate-model-properties-file
+  language: python
+  types: [sql]
+  args:
+    [
+      "--properties-file",
+      "/Users/tomsejr/Documents/03-Workspace/Private/jaffle_shop/{database}/{schema}/{name}.yml",
+    ]
+  require_serial: true
+- id: unify-column-description
+  name: Unify column description
+  description: Unify column descriptions across all models
+  entry: unify-column-description
+  language: python
+  files: '.*\.(yml|yaml)$'
+  require_serial: true
+- id: replace-script-table-names
+  name: Replace script table names
+  description: Replace table names with source or ref macros in the script.
+  entry: replace-script-table-names
+  language: python
+  types: [sql]
+- id: remove-script-semicolon
+  name: Remove script semicolon
+  description: Remove semicolon at the end of the script.
+  entry: remove-script-semicolon
+  language: python
+  types: [sql]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -9,7 +9,7 @@
   description: Check column name abides to contract.
   entry: check-column-name-contract
   language: python
-  types: [sql, yaml]
+  types_or: [sql, yaml]
 - id: check-macro-has-description
   name: Check the macro has description
   description: Ensures that the macro has description in properties file.
@@ -36,7 +36,7 @@
   description: Ensures that all columns in database are specified in properties file.
   entry: check-model-has-all-columns
   language: python
-  types: [sql, yaml]
+  types_or: [sql, yaml]
 - id: check-model-has-description
   name: Check the model has description
   description: Ensures that the model has description in properties file.
@@ -56,37 +56,37 @@
   description: Ensures that the model has properties file (schema file).
   entry: check-model-has-properties-file
   language: python
-  types: [sql, yaml]
+  types_or: [sql, yaml]
 - id: check-model-has-tests-by-group
   name: Check the model has a number of tests from a group of tests.
   description: Ensures that the model has a number of tests from a group of tests.
   entry: check-model-has-tests-by-group
   language: python
-  types: [sql, yaml]
+  types_or: [sql, yaml]
 - id: check-model-has-tests-by-name
   name: Check the model tests by a test name
   description: Ensures that the model has a number of tests of a certain name (e.g. data, unique).
   entry: check-model-has-tests-by-name
   language: python
-  types: [sql, yaml]
+  types_or: [sql, yaml]
 - id: check-model-has-tests-by-type
   name: Check the model tests by a test type
   description: Ensures that the model has a number of tests of a certain type (data, schema).
   entry: check-model-has-tests-by-type
   language: python
-  types: [sql, yaml]
+  types_or: [sql, yaml]
 - id: check-model-has-tests
   name: Check the model has a tests
   description: Ensures that the model has a number of tests.
   entry: check-model-has-tests
   language: python
-  types: [sql, yaml]
+  types_or: [sql, yaml]
 - id: check-model-name-contract
   name: Check model name contract
   description: Check model name abides to contract.
   entry: check-model-name-contract
   language: python
-  types: [sql]
+  types_or: [sql]
 - id: check-model-parents-schema
   name: Check parent models or sources are from certain schema
   entry: check-model-parents-schema
@@ -97,37 +97,37 @@
   description: Ensures the model has a specific number (max/min) of parents or/and childs.
   entry: check-model-parents-and-childs
   language: python
-  types: [sql, yaml]
+  types_or: [sql, yaml]
 - id: check-model-tags
   name: Check the model has valid tags
   description: Ensures that the model has only valid tags from the provided list.
   entry: check-model-tags
   language: python
-  types: [sql, yaml]
+  types_or: [sql, yaml]
 - id: check-script-has-no-table-name
   name: Check the script has not table name
   description: Ensures that the script is using only source or ref macro to specify the table name.
   entry: check-script-has-no-table-name
   language: python
-  types: [sql]
+  types_or: [sql]
 - id: check-script-ref-and-source
   name: Check the script has existing refs and sources
   description: Ensures that the script contains only existing sources or macros.
   entry: check-script-ref-and-source
   language: python
-  types: [sql]
+  types_or: [sql]
 - id: check-script-semicolon
   name: Check the script does not contain a semicolon
   description: Ensure that the script does not have a semicolon at the end of the file.
   entry: check-script-semicolon
   language: python
-  types: [sql]
+  types_or: [sql]
 - id: check-source-childs
   name: Check the source has a specific number (max/min) of childs.
   description: Ensures the source has a specific number (max/min) of childs.
   entry: check-source-childs
   language: python
-  types: [sql]
+  types_or: [sql]
 - id: check-source-columns-have-desc
   name: Check for source column descriptions
   description: Ensures that the source has columns with descriptions in the properties file.
@@ -199,7 +199,7 @@
   description: Generates executable SQL from source model, test, and analysis files.
   entry: dbt-compile
   language: python
-  types: [sql]
+  types_or: [sql]
   require_serial: true
 - id: dbt-deps
   name: dbt deps
@@ -219,26 +219,26 @@
   entry: dbt-run
   language: python
   require_serial: true
-  types: [sql]
+  types_or: [sql]
 - id: dbt-test
   name: dbt test
   description: Runs tests on data in deployed models.
   entry: dbt-test
   language: python
   require_serial: true
-  types: [sql]
+  types_or: [sql]
 - id: generate-missing-sources
   name: Generate missing sources
   description: If any source is missing this hook tries to create it.
   entry: generate-missing-sources
   language: python
-  types: [sql]
+  types_or: [sql]
 - id: generate-model-properties-file
   name: Generate model properties file
   description: Generate model properties file if does not exists.
   entry: generate-model-properties-file
   language: python
-  types: [sql]
+  types_or: [sql]
   args:
     [
       "--properties-file",
@@ -257,10 +257,10 @@
   description: Replace table names with source or ref macros in the script.
   entry: replace-script-table-names
   language: python
-  types: [sql]
+  types_or: [sql]
 - id: remove-script-semicolon
   name: Remove script semicolon
   description: Remove semicolon at the end of the script.
   entry: remove-script-semicolon
   language: python
-  types: [sql]
+  types_or: [sql]

--- a/pre_commit_dbt/check_column_desc_are_same.py
+++ b/pre_commit_dbt/check_column_desc_are_same.py
@@ -13,6 +13,9 @@ from pre_commit_dbt.utils import add_filenames_args
 from pre_commit_dbt.utils import get_filenames
 from pre_commit_dbt.utils import get_model_schemas
 from pre_commit_dbt.utils import ModelSchema
+from rich.console import Console
+
+console = Console()
 
 
 @dataclass
@@ -58,9 +61,11 @@ def check_column_desc(paths: Sequence[str], ignore: Optional[Sequence[str]]) -> 
         group_cnt = Counter([group.description for group in groups])
         if len(group_cnt.keys()) > 1:
             status_code = 1
-            print(f"{name}: has different descriptions:")
+            console.print(f"[red]{name}[/red]: has different descriptions:")
             for desc, cnt in group_cnt.items():
-                print("  - (%s): %s" % (cnt, desc))
+                console.print(
+                    "  - [yellow](%s)[/yellow]: [yellow]%s[/yellow]" % (cnt, desc)
+                )
     return status_code
 
 

--- a/pre_commit_dbt/check_column_desc_are_same.py
+++ b/pre_commit_dbt/check_column_desc_are_same.py
@@ -13,9 +13,8 @@ from pre_commit_dbt.utils import add_filenames_args
 from pre_commit_dbt.utils import get_filenames
 from pre_commit_dbt.utils import get_model_schemas
 from pre_commit_dbt.utils import ModelSchema
-from rich.console import Console
-
-console = Console()
+from pre_commit_dbt.utils import color_string_red
+from pre_commit_dbt.utils import color_string_yellow
 
 
 @dataclass
@@ -61,11 +60,9 @@ def check_column_desc(paths: Sequence[str], ignore: Optional[Sequence[str]]) -> 
         group_cnt = Counter([group.description for group in groups])
         if len(group_cnt.keys()) > 1:
             status_code = 1
-            console.print(f"[red]{name}[/red]: has different descriptions:")
+            print(f"{color_string_red(name)}: has different descriptions:")
             for desc, cnt in group_cnt.items():
-                console.print(
-                    "  - [yellow](%s)[/yellow]: [yellow]%s[/yellow]" % (cnt, desc)
-                )
+                print(f"  - {color_string_yellow(cnt)}: {color_string_yellow(desc)}")
     return status_code
 
 

--- a/pre_commit_dbt/check_column_name_contract.py
+++ b/pre_commit_dbt/check_column_name_contract.py
@@ -11,10 +11,8 @@ from pre_commit_dbt.utils import get_filenames
 from pre_commit_dbt.utils import get_json
 from pre_commit_dbt.utils import get_models
 from pre_commit_dbt.utils import JsonOpenError
-from pre_commit_dbt.utils import get_missing_file_paths
-from rich.console import Console
-
-console = Console()
+from pre_commit_dbt.utils import color_string_red
+from pre_commit_dbt.utils import color_string_yellow
 
 
 def check_column_name_contract(
@@ -34,17 +32,17 @@ def check_column_name_contract(
             if dtype == col_type:
                 if re.match(pattern, col_name) is None:
                     status_code = 1
-                    console.print(
-                        f"[red]{col_name}[/red]: column is of type [yellow]{dtype}[/yellow] and "
-                        f"does not match regex pattern [yellow]{pattern}[/yellow]."
+                    print(
+                        f"{color_string_red(col_name)}: column is of type {color_string_yellow(dtype)} and "
+                        f"does not match regex pattern {color_string_yellow(pattern)}."
                     )
 
             # Check all files with naming pattern are of type dtype
             elif re.match(pattern, col_name):
                 status_code = 1
-                console.print(
-                    f"[red]{col_name}[/red]: column name matches regex pattern [yellow]{pattern}[/yellow] "
-                    f"and is of type [yellow]{col_type}[/yellow] instead of [yellow]{dtype}[/yellow]."
+                print(
+                    f"{color_string_red(col_name)}: column name matches regex pattern {color_string_yellow(pattern)} "
+                    f"and is of type {color_string_yellow(col_type)} instead of {color_string_yellow(dtype)}."
                 )
 
     return status_code

--- a/pre_commit_dbt/check_column_name_contract.py
+++ b/pre_commit_dbt/check_column_name_contract.py
@@ -12,13 +12,14 @@ from pre_commit_dbt.utils import get_json
 from pre_commit_dbt.utils import get_models
 from pre_commit_dbt.utils import JsonOpenError
 from pre_commit_dbt.utils import get_missing_file_paths
+from rich.console import Console
+
+console = Console()
 
 
 def check_column_name_contract(
     paths: Sequence[str], pattern: str, dtype: str, catalog: Dict[str, Any]
 ) -> int:
-    paths = get_missing_file_paths(paths, manifest)
-
     status_code = 0
     sqls = get_filenames(paths, [".sql"])
     filenames = set(sqls.keys())
@@ -33,17 +34,17 @@ def check_column_name_contract(
             if dtype == col_type:
                 if re.match(pattern, col_name) is None:
                     status_code = 1
-                    print(
-                        f"{col_name}: column is of type {dtype} and "
-                        f"does not match regex pattern {pattern}."
+                    console.print(
+                        f"[red]{col_name}[/red]: column is of type [yellow]{dtype}[/yellow] and "
+                        f"does not match regex pattern [yellow]{pattern}[/yellow]."
                     )
 
             # Check all files with naming pattern are of type dtype
             elif re.match(pattern, col_name):
                 status_code = 1
-                print(
-                    f"{col_name}: column name matches regex pattern {pattern} "
-                    f"and is of type {col_type} instead of {dtype}."
+                console.print(
+                    f"[red]{col_name}[/red]: column name matches regex pattern [yellow]{pattern}[/yellow] "
+                    f"and is of type [yellow]{col_type}[/yellow] instead of [yellow]{dtype}[/yellow]."
                 )
 
     return status_code

--- a/pre_commit_dbt/check_macro_arguments_have_desc.py
+++ b/pre_commit_dbt/check_macro_arguments_have_desc.py
@@ -17,9 +17,8 @@ from pre_commit_dbt.utils import get_macros
 from pre_commit_dbt.utils import JsonOpenError
 from pre_commit_dbt.utils import Macro
 from pre_commit_dbt.utils import MacroSchema
-from rich.console import Console
-
-console = Console()
+from pre_commit_dbt.utils import color_string_red
+from pre_commit_dbt.utils import color_string_yellow
 
 
 def check_argument_desc(
@@ -68,9 +67,9 @@ def check_argument_desc(
         if arguments:
             status_code = 1
             result = "\n- ".join(list(arguments))  # pragma: no mutate
-            console.print(
-                f"[red]{sqls.get(macro)}[/red]: "
-                f"following arguments are missing description:\n- [yellow]{result}[/yellow]",
+            print(
+                f"{color_string_red(sqls.get(macro))}: "
+                f"following arguments are missing description:\n- {color_string_yellow(result)}",
             )
     return status_code, missing
 

--- a/pre_commit_dbt/check_macro_arguments_have_desc.py
+++ b/pre_commit_dbt/check_macro_arguments_have_desc.py
@@ -17,6 +17,9 @@ from pre_commit_dbt.utils import get_macros
 from pre_commit_dbt.utils import JsonOpenError
 from pre_commit_dbt.utils import Macro
 from pre_commit_dbt.utils import MacroSchema
+from rich.console import Console
+
+console = Console()
 
 
 def check_argument_desc(
@@ -65,9 +68,9 @@ def check_argument_desc(
         if arguments:
             status_code = 1
             result = "\n- ".join(list(arguments))  # pragma: no mutate
-            print(
-                f"{sqls.get(macro)}: "
-                f"following arguments are missing description:\n- {result}",
+            console.print(
+                f"[red]{sqls.get(macro)}[/red]: "
+                f"following arguments are missing description:\n- [yellow]{result}[/yellow]",
             )
     return status_code, missing
 

--- a/pre_commit_dbt/check_macro_has_description.py
+++ b/pre_commit_dbt/check_macro_has_description.py
@@ -12,6 +12,9 @@ from pre_commit_dbt.utils import get_macro_schemas
 from pre_commit_dbt.utils import get_macro_sqls
 from pre_commit_dbt.utils import get_macros
 from pre_commit_dbt.utils import JsonOpenError
+from rich.console import Console
+
+console = Console()
 
 
 def has_description(paths: Sequence[str], manifest: Dict[str, Any]) -> int:
@@ -33,8 +36,8 @@ def has_description(paths: Sequence[str], manifest: Dict[str, Any]) -> int:
 
     for macro in missing:
         status_code = 1
-        print(
-            f"{sqls.get(macro)}: "
+        console.print(
+            f"[red]{sqls.get(macro)}[/red]: "
             f"does not have defined description or properties file is missing.",
         )
     return status_code

--- a/pre_commit_dbt/check_macro_has_description.py
+++ b/pre_commit_dbt/check_macro_has_description.py
@@ -12,9 +12,7 @@ from pre_commit_dbt.utils import get_macro_schemas
 from pre_commit_dbt.utils import get_macro_sqls
 from pre_commit_dbt.utils import get_macros
 from pre_commit_dbt.utils import JsonOpenError
-from rich.console import Console
-
-console = Console()
+from pre_commit_dbt.utils import color_string_red
 
 
 def has_description(paths: Sequence[str], manifest: Dict[str, Any]) -> int:
@@ -36,8 +34,8 @@ def has_description(paths: Sequence[str], manifest: Dict[str, Any]) -> int:
 
     for macro in missing:
         status_code = 1
-        console.print(
-            f"[red]{sqls.get(macro)}[/red]: "
+        print(
+            f"{color_string_red(sqls.get(macro))}: "
             f"does not have defined description or properties file is missing.",
         )
     return status_code

--- a/pre_commit_dbt/check_model_columns_have_desc.py
+++ b/pre_commit_dbt/check_model_columns_have_desc.py
@@ -18,9 +18,8 @@ from pre_commit_dbt.utils import JsonOpenError
 from pre_commit_dbt.utils import Model
 from pre_commit_dbt.utils import ModelSchema
 from pre_commit_dbt.utils import get_missing_file_paths
-from rich.console import Console
-
-console = Console()
+from pre_commit_dbt.utils import color_string_red
+from pre_commit_dbt.utils import color_string_yellow
 
 
 def check_column_desc(
@@ -71,9 +70,9 @@ def check_column_desc(
         if columns:
             status_code = 1
             result = "\n- ".join(list(columns))  # pragma: no mutate
-            console.print(
-                f"[red]{sqls.get(model)}[/red]: "
-                f"following columns are missing description:\n- [yellow]{result}[/yellow]",
+            print(
+                f"{color_string_red(sqls.get(model))}: "
+                f"following columns are missing description:\n- {color_string_yellow(result)}",
             )
     return status_code, missing
 

--- a/pre_commit_dbt/check_model_columns_have_desc.py
+++ b/pre_commit_dbt/check_model_columns_have_desc.py
@@ -18,6 +18,9 @@ from pre_commit_dbt.utils import JsonOpenError
 from pre_commit_dbt.utils import Model
 from pre_commit_dbt.utils import ModelSchema
 from pre_commit_dbt.utils import get_missing_file_paths
+from rich.console import Console
+
+console = Console()
 
 
 def check_column_desc(
@@ -68,9 +71,9 @@ def check_column_desc(
         if columns:
             status_code = 1
             result = "\n- ".join(list(columns))  # pragma: no mutate
-            print(
-                f"{sqls.get(model)}: "
-                f"following columns are missing description:\n- {result}",
+            console.print(
+                f"[red]{sqls.get(model)}[/red]: "
+                f"following columns are missing description:\n- [yellow]{result}[/yellow]",
             )
     return status_code, missing
 

--- a/pre_commit_dbt/check_model_has_all_columns.py
+++ b/pre_commit_dbt/check_model_has_all_columns.py
@@ -6,8 +6,6 @@ from typing import Sequence
 from typing import Set
 from typing import Tuple
 
-from rich.console import Console
-
 from pre_commit_dbt.utils import add_catalog_args
 from pre_commit_dbt.utils import add_filenames_args
 from pre_commit_dbt.utils import add_manifest_args
@@ -16,8 +14,8 @@ from pre_commit_dbt.utils import get_model_sqls
 from pre_commit_dbt.utils import get_models
 from pre_commit_dbt.utils import JsonOpenError
 from pre_commit_dbt.utils import get_missing_file_paths
-
-console = Console()
+from pre_commit_dbt.utils import color_string_red
+from pre_commit_dbt.utils import color_string_yellow
 
 
 def compare_columns(
@@ -57,33 +55,33 @@ def check_model_columns(
             if model_only:
                 status_code = 1
                 print_cols = [
-                    "- name: [yellow]%s[/yellow]" % (col) for col in model_only if col
+                    "- name: %s" % color_string_yellow(col) for col in model_only if col
                 ]
-                console.print(
-                    "Columns in [yellow]{schema_path}[/yellow], but not in Database ([red]{file}[/red]):\n"
+                print(
+                    "Columns in {schema_path}, but not in Database ({file}):\n"
                     "{columns}".format(
-                        file=sqls.get(model.filename),
+                        file=color_string_red(sqls.get(model.filename)),
                         columns="\n".join(print_cols),  # pragma: no mutate
-                        schema_path=schema_path,
+                        schema_path=color_string_yellow(schema_path),
                     )
                 )
             if catalog_only:
                 status_code = 1
                 print_cols = [
-                    "- name: [red]%s[/red]" % (col) for col in catalog_only if col
+                    "- name: %s" % color_string_red(col) for col in catalog_only if col
                 ]
                 print(
-                    "Columns in Database ([red]{file}[/red]), but not in [yellow]{schema_path}[/yellow]:\n"
+                    "Columns in Database ({file}), but not in {schema_path}:\n"
                     "{columns}".format(
-                        file=sqls.get(model.filename),
+                        file=color_string_red(sqls.get(model.filename)),
                         columns="\n".join(print_cols),  # pragma: no mutate
-                        schema_path=schema_path,
+                        schema_path=color_string_yellow(schema_path),
                     )
                 )
         else:
             status_code = 1
-            console.print(
-                f"Unable to find model [red]`{model.model_id}`[/red] in catalog file. "
+            print(
+                f"Unable to find model `{color_string_red(model.model_id)}` in catalog file. "
                 f"Make sure you run `dbt docs generate` before executing this hook."
             )
     return status_code

--- a/pre_commit_dbt/check_model_has_all_columns.py
+++ b/pre_commit_dbt/check_model_has_all_columns.py
@@ -6,6 +6,8 @@ from typing import Sequence
 from typing import Set
 from typing import Tuple
 
+from rich.console import Console
+
 from pre_commit_dbt.utils import add_catalog_args
 from pre_commit_dbt.utils import add_filenames_args
 from pre_commit_dbt.utils import add_manifest_args
@@ -15,6 +17,7 @@ from pre_commit_dbt.utils import get_models
 from pre_commit_dbt.utils import JsonOpenError
 from pre_commit_dbt.utils import get_missing_file_paths
 
+console = Console()
 
 def compare_columns(
     catalog_columns: Dict[str, Any], model_columns: Dict[str, Any]
@@ -52,30 +55,18 @@ def check_model_columns(
                 schema_path = "any .yml file"
             if model_only:
                 status_code = 1
-                print_cols = ["- name: %s" % (col) for col in model_only if col]
-                print(
-                    "{file}: columns in {schema_path} but not in db (catalog.json):\n"
-                    "{columns}".format(
-                        file=sqls.get(model.filename),
-                        columns="\n".join(print_cols),  # pragma: no mutate
-                        schema_path=schema_path,
-                    )
-                )
+                print_cols = ["- name: [yellow]%s[/yellow]" % (col) for col in model_only if col]
+                console.print(f"[red]{sqls.get(model.filename)}[/red]: columns in [yellow]{schema_path}[/yellow] but not in Database:")
+                console.print(f"{'\n'.join(print_cols)}")
             if catalog_only:
                 status_code = 1
-                print_cols = ["- name: %s" % (col) for col in catalog_only if col]
-                print(
-                    "{file}: columns in db (catalog.json) but not in {schema_path}:\n"
-                    "{columns}".format(
-                        file=sqls.get(model.filename),
-                        columns="\n".join(print_cols),  # pragma: no mutate
-                        schema_path=schema_path,
-                    )
-                )
+                print_cols = ["- name: [yellow]%s[/yellow]" % (col) for col in catalog_only if col]
+                console.print(f"[red]{sqls.get(model.filename)}[/red]: columns in Database but not in [yellow]{schema_path}[/yellow]:")
+                console.print(f"{'\n'.join(print_cols)}")
         else:
             status_code = 1
-            print(
-                f"Unable to find model `{model.model_id}` in catalog file. "
+            console.print(
+                f"Unable to find model [red]`{model.model_id}`[/red] in catalog file. "
                 f"Make sure you run `dbt docs generate` before executing this hook."
             )
     return status_code

--- a/pre_commit_dbt/check_model_has_all_columns.py
+++ b/pre_commit_dbt/check_model_has_all_columns.py
@@ -49,7 +49,7 @@ def check_model_columns(
             )
             schema_path = model.node.get("patch_path", "schema")  # pragma: no mutate
             if not schema_path:
-                schema_path = "any YML file"
+                schema_path = "any .yml file"
             if model_only:
                 status_code = 1
                 print_cols = ["- name: %s" % (col) for col in model_only if col]

--- a/pre_commit_dbt/check_model_has_all_columns.py
+++ b/pre_commit_dbt/check_model_has_all_columns.py
@@ -56,10 +56,12 @@ def check_model_columns(
                 schema_path = "any .yml file"
             if model_only:
                 status_code = 1
-                print_cols = ["- name: %s" % (col) for col in model_only if col]
+                print_cols = [
+                    "- name: [yellow]%s[/yellow]" % (col) for col in model_only if col
+                ]
                 console.print(
-                    "[red]{file}[/red]: columns in [yellow]{schema_path}[/yellow] but not in Database:\n"
-                    "[yellow]{columns}[/yellow]".format(
+                    "Columns in [yellow]{schema_path}[/yellow], but not in Database ([red]{file}[/red]):\n"
+                    "{columns}".format(
                         file=sqls.get(model.filename),
                         columns="\n".join(print_cols),  # pragma: no mutate
                         schema_path=schema_path,
@@ -67,10 +69,12 @@ def check_model_columns(
                 )
             if catalog_only:
                 status_code = 1
-                print_cols = ["- name: %s" % (col) for col in catalog_only if col]
+                print_cols = [
+                    "- name: [red]%s[/red]" % (col) for col in catalog_only if col
+                ]
                 print(
-                    "[red]{file}[/red]: columns in Database but not in [yellow]{schema_path}[/yellow]:\n"
-                    "[yellow]{columns}[/yellow]".format(
+                    "Columns in Database ([red]{file}[/red]), but not in [yellow]{schema_path}[/yellow]:\n"
+                    "{columns}".format(
                         file=sqls.get(model.filename),
                         columns="\n".join(print_cols),  # pragma: no mutate
                         schema_path=schema_path,

--- a/pre_commit_dbt/check_model_has_all_columns.py
+++ b/pre_commit_dbt/check_model_has_all_columns.py
@@ -48,6 +48,8 @@ def check_model_columns(
                 model_columns=model.node.get("columns", {}),
             )
             schema_path = model.node.get("patch_path", "schema")  # pragma: no mutate
+            if not schema_path:
+                schema_path = "any YML file"
             if model_only:
                 status_code = 1
                 print_cols = ["- name: %s" % (col) for col in model_only if col]

--- a/pre_commit_dbt/check_model_has_all_columns.py
+++ b/pre_commit_dbt/check_model_has_all_columns.py
@@ -19,6 +19,7 @@ from pre_commit_dbt.utils import get_missing_file_paths
 
 console = Console()
 
+
 def compare_columns(
     catalog_columns: Dict[str, Any], model_columns: Dict[str, Any]
 ) -> Tuple[Set[str], Set[str]]:
@@ -55,14 +56,26 @@ def check_model_columns(
                 schema_path = "any .yml file"
             if model_only:
                 status_code = 1
-                print_cols = ["- name: [yellow]%s[/yellow]" % (col) for col in model_only if col]
-                console.print(f"[red]{sqls.get(model.filename)}[/red]: columns in [yellow]{schema_path}[/yellow] but not in Database:")
-                console.print(f"{'\n'.join(print_cols)}")
+                print_cols = ["- name: %s" % (col) for col in model_only if col]
+                console.print(
+                    "[red]{file}[/red]: columns in [yellow]{schema_path}[/yellow] but not in Database:\n"
+                    "[yellow]{columns}[/yellow]".format(
+                        file=sqls.get(model.filename),
+                        columns="\n".join(print_cols),  # pragma: no mutate
+                        schema_path=schema_path,
+                    )
+                )
             if catalog_only:
                 status_code = 1
-                print_cols = ["- name: [yellow]%s[/yellow]" % (col) for col in catalog_only if col]
-                console.print(f"[red]{sqls.get(model.filename)}[/red]: columns in Database but not in [yellow]{schema_path}[/yellow]:")
-                console.print(f"{'\n'.join(print_cols)}")
+                print_cols = ["- name: %s" % (col) for col in catalog_only if col]
+                print(
+                    "[red]{file}[/red]: columns in Database but not in [yellow]{schema_path}[/yellow]:\n"
+                    "[yellow]{columns}[/yellow]".format(
+                        file=sqls.get(model.filename),
+                        columns="\n".join(print_cols),  # pragma: no mutate
+                        schema_path=schema_path,
+                    )
+                )
         else:
             status_code = 1
             console.print(

--- a/pre_commit_dbt/check_model_has_description.py
+++ b/pre_commit_dbt/check_model_has_description.py
@@ -13,9 +13,7 @@ from pre_commit_dbt.utils import get_model_sqls
 from pre_commit_dbt.utils import get_models
 from pre_commit_dbt.utils import JsonOpenError
 from pre_commit_dbt.utils import get_missing_file_paths
-from rich.console import Console
-
-console = Console()
+from pre_commit_dbt.utils import color_string_red
 
 
 def has_description(paths: Sequence[str], manifest: Dict[str, Any]) -> int:
@@ -40,8 +38,8 @@ def has_description(paths: Sequence[str], manifest: Dict[str, Any]) -> int:
 
     for model in missing:
         status_code = 1
-        console.print(
-            f"[red]{sqls.get(model)}[/red]: "
+        print(
+            f"{color_string_red(sqls.get(model))}: "
             f"does not have defined description or properties file is missing.",
         )
     return status_code

--- a/pre_commit_dbt/check_model_has_description.py
+++ b/pre_commit_dbt/check_model_has_description.py
@@ -13,6 +13,9 @@ from pre_commit_dbt.utils import get_model_sqls
 from pre_commit_dbt.utils import get_models
 from pre_commit_dbt.utils import JsonOpenError
 from pre_commit_dbt.utils import get_missing_file_paths
+from rich.console import Console
+
+console = Console()
 
 
 def has_description(paths: Sequence[str], manifest: Dict[str, Any]) -> int:
@@ -37,8 +40,8 @@ def has_description(paths: Sequence[str], manifest: Dict[str, Any]) -> int:
 
     for model in missing:
         status_code = 1
-        print(
-            f"{sqls.get(model)}: "
+        console.print(
+            f"[red]{sqls.get(model)}[/red]: "
             f"does not have defined description or properties file is missing.",
         )
     return status_code

--- a/pre_commit_dbt/check_model_has_properties_file.py
+++ b/pre_commit_dbt/check_model_has_properties_file.py
@@ -13,9 +13,7 @@ from pre_commit_dbt.utils import get_model_sqls
 from pre_commit_dbt.utils import get_models
 from pre_commit_dbt.utils import JsonOpenError
 from pre_commit_dbt.utils import get_missing_file_paths
-from rich.console import Console
-
-console = Console()
+from pre_commit_dbt.utils import color_string_red
 
 
 def has_properties_file(
@@ -35,8 +33,8 @@ def has_properties_file(
 
     for model in missing:
         status_code = 1
-        console.print(
-            f"[red]{sqls.get(model)}[/red]: "
+        print(
+            f"{color_string_red(sqls.get(model))}: "
             f"does not have model properties defined in any .yml file.",
         )
     return status_code, missing

--- a/pre_commit_dbt/check_model_has_properties_file.py
+++ b/pre_commit_dbt/check_model_has_properties_file.py
@@ -13,6 +13,9 @@ from pre_commit_dbt.utils import get_model_sqls
 from pre_commit_dbt.utils import get_models
 from pre_commit_dbt.utils import JsonOpenError
 from pre_commit_dbt.utils import get_missing_file_paths
+from rich.console import Console
+
+console = Console()
 
 
 def has_properties_file(
@@ -32,8 +35,8 @@ def has_properties_file(
 
     for model in missing:
         status_code = 1
-        print(
-            f"{sqls.get(model)}: "
+        console.print(
+            f"[red]{sqls.get(model)}[/red]: "
             f"does not have model properties defined in any .yml file.",
         )
     return status_code, missing

--- a/pre_commit_dbt/check_script_has_no_table_name.py
+++ b/pre_commit_dbt/check_script_has_no_table_name.py
@@ -6,11 +6,10 @@ from typing import Optional
 from typing import Sequence
 from typing import Set
 from typing import Tuple
+from pre_commit_dbt.utils import color_string_red
+from pre_commit_dbt.utils import color_string_yellow
 
 from pre_commit_dbt.utils import add_filenames_args
-from rich.console import Console
-
-console = Console()
 
 REGEX_COMMENTS = r"(?<=(\/\*|\{#))((.|[\r\n])+?)(?=(\*+\/|#\}))|[ \t]*--.*"
 REGEX_SPLIT = r"[\s]+"
@@ -91,9 +90,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         )
         if status_code_file:
             result = "\n- ".join(list(tables))  # pragma: no mutate
-            console.print(
-                f"[red]{filename}[/red]: "
-                f"does not use source() or ref() macros for tables:\n- [yellow]{result}[/yellow]",
+            print(
+                f"{color_string_red(filename)}: "
+                f"does not use source() or ref() macros for tables:\n- {color_string_yellow(result)}",
             )
             status_code = status_code_file
 

--- a/pre_commit_dbt/check_script_has_no_table_name.py
+++ b/pre_commit_dbt/check_script_has_no_table_name.py
@@ -8,10 +8,11 @@ from typing import Set
 from typing import Tuple
 
 from pre_commit_dbt.utils import add_filenames_args
+from rich.console import Console
 
-REGEX_COMMENTS = (
-    r"(?<=(\/\*|\{#))((.|[\r\n])+?)(?=(\*+\/|#\}))|[ \t]*--.*"
-)
+console = Console()
+
+REGEX_COMMENTS = r"(?<=(\/\*|\{#))((.|[\r\n])+?)(?=(\*+\/|#\}))|[ \t]*--.*"
 REGEX_SPLIT = r"[\s]+"
 IGNORE_WORDS = ["", "(", "{{"]  # pragma: no mutate
 REGEX_PARENTHESIS = r"([\(\)])"  # pragma: no mutate
@@ -90,9 +91,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         )
         if status_code_file:
             result = "\n- ".join(list(tables))  # pragma: no mutate
-            print(
-                f"{filename}: "
-                f"does not use source() or ref() macros for tables:\n- {result}",
+            console.print(
+                f"[red]{filename}[/red]: "
+                f"does not use source() or ref() macros for tables:\n- [yellow]{result}[/yellow]",
             )
             status_code = status_code_file
 

--- a/pre_commit_dbt/check_script_ref_and_source.py
+++ b/pre_commit_dbt/check_script_ref_and_source.py
@@ -8,14 +8,12 @@ from typing import Sequence
 from typing import Set
 from typing import Tuple
 
-from pre_commit_dbt.utils import add_filenames_args
+from pre_commit_dbt.utils import add_filenames_args, color_string_red
 from pre_commit_dbt.utils import add_manifest_args
 from pre_commit_dbt.utils import get_filenames
 from pre_commit_dbt.utils import get_json
 from pre_commit_dbt.utils import JsonOpenError
-from rich.console import Console
-
-console = Console()
+from pre_commit_dbt.utils import color_string_red
 
 
 def check_refs_sources(
@@ -61,11 +59,11 @@ def check_refs_sources(
         status_code = 1
         source_name = src.get("source_name")  # pragma: no mutate
         table_name = src.get("table_name")  # pragma: no mutate
-        console.print(f"Missing source [red]`{source_name}.{table_name}`[/red]")
+        print(f"Missing source `{color_string_red(f'{source_name}.{table_name}')}`")
 
     for missing_ref in models:
         status_code = 1
-        console.print(f"Missing model (ref) [red]{missing_ref}[/red]")
+        print(f"Missing model (ref) {color_string_red(missing_ref)}")
 
     return status_code, models, sources
 

--- a/pre_commit_dbt/check_script_ref_and_source.py
+++ b/pre_commit_dbt/check_script_ref_and_source.py
@@ -13,6 +13,9 @@ from pre_commit_dbt.utils import add_manifest_args
 from pre_commit_dbt.utils import get_filenames
 from pre_commit_dbt.utils import get_json
 from pre_commit_dbt.utils import JsonOpenError
+from rich.console import Console
+
+console = Console()
 
 
 def check_refs_sources(
@@ -58,11 +61,11 @@ def check_refs_sources(
         status_code = 1
         source_name = src.get("source_name")  # pragma: no mutate
         table_name = src.get("table_name")  # pragma: no mutate
-        print(f"Missing source `{source_name}.{table_name}`")
+        console.print(f"Missing source [red]`{source_name}.{table_name}`[/red]")
 
     for missing_ref in models:
         status_code = 1
-        print(f"Missing model (ref) {missing_ref}")
+        console.print(f"Missing model (ref) [red]{missing_ref}[/red]")
 
     return status_code, models, sources
 

--- a/pre_commit_dbt/check_script_semicolon.py
+++ b/pre_commit_dbt/check_script_semicolon.py
@@ -5,9 +5,7 @@ from typing import Optional
 from typing import Sequence
 
 from pre_commit_dbt.utils import add_filenames_args
-from rich.console import Console
-
-console = Console()
+from pre_commit_dbt.utils import color_string_red
 
 
 def check_semicolon(file_obj: IO[bytes], replace: bool = False) -> int:
@@ -50,8 +48,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         with open(filename, "rb+") as file_obj:
             status_code_file = check_semicolon(file_obj)
             if status_code_file:
-                console.print(
-                    f"[red]{filename}[/red]: contains a semicolon at the end. "
+                print(
+                    f"{color_string_red(filename)}: contains a semicolon at the end. "
                     f"dbt does not support that."
                 )
                 status_code = status_code_file

--- a/pre_commit_dbt/check_script_semicolon.py
+++ b/pre_commit_dbt/check_script_semicolon.py
@@ -5,6 +5,9 @@ from typing import Optional
 from typing import Sequence
 
 from pre_commit_dbt.utils import add_filenames_args
+from rich.console import Console
+
+console = Console()
 
 
 def check_semicolon(file_obj: IO[bytes], replace: bool = False) -> int:
@@ -47,8 +50,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         with open(filename, "rb+") as file_obj:
             status_code_file = check_semicolon(file_obj)
             if status_code_file:
-                print(
-                    f"{filename}: contains a semicolon at the end. "
+                console.print(
+                    f"[red]{filename}[/red]: contains a semicolon at the end. "
                     f"dbt does not support that."
                 )
                 status_code = status_code_file

--- a/pre_commit_dbt/check_source_has_freshness.py
+++ b/pre_commit_dbt/check_source_has_freshness.py
@@ -6,6 +6,9 @@ from typing import Set
 
 from pre_commit_dbt.utils import add_filenames_args
 from pre_commit_dbt.utils import get_source_schemas
+from rich.console import Console
+
+console = Console()
 
 
 def has_freshness(paths: Sequence[str], required_freshness: Set[str]) -> int:
@@ -27,18 +30,18 @@ def has_freshness(paths: Sequence[str], required_freshness: Set[str]) -> int:
         loaded = table.get("loaded_at_field") or source.get("loaded_at_field")
         if not loaded:
             status_code = 1
-            print(
-                f"{schema.source_name}.{schema.table_name}: "
+            console.print(
+                f"[red]{schema.source_name}.{schema.table_name}[/red]: "
                 f"is missing `loaded_at_field` which is required for freshness."
             )
         if not (freshness == required_freshness):
             status_code = 1
             missing_params = required_freshness.difference(freshness)
             result = "\n- ".join(list(missing_params))  # pragma: no mutate
-            print(
-                f"{schema.source_name}.{schema.table_name}: "
+            console.print(
+                f"[red]{schema.source_name}.{schema.table_name}[/red]: "
                 f"miss some required freshness parameters:"
-                f"\n- {result} "
+                f"\n- [yellow]{result}[/yellow] "
             )
     return status_code
 

--- a/pre_commit_dbt/check_source_has_freshness.py
+++ b/pre_commit_dbt/check_source_has_freshness.py
@@ -6,9 +6,8 @@ from typing import Set
 
 from pre_commit_dbt.utils import add_filenames_args
 from pre_commit_dbt.utils import get_source_schemas
-from rich.console import Console
-
-console = Console()
+from pre_commit_dbt.utils import color_string_red
+from pre_commit_dbt.utils import color_string_yellow
 
 
 def has_freshness(paths: Sequence[str], required_freshness: Set[str]) -> int:
@@ -30,18 +29,18 @@ def has_freshness(paths: Sequence[str], required_freshness: Set[str]) -> int:
         loaded = table.get("loaded_at_field") or source.get("loaded_at_field")
         if not loaded:
             status_code = 1
-            console.print(
-                f"[red]{schema.source_name}.{schema.table_name}[/red]: "
+            print(
+                f"{color_string_red(f'{schema.source_name}.{schema.table_name}')}: "
                 f"is missing `loaded_at_field` which is required for freshness."
             )
         if not (freshness == required_freshness):
             status_code = 1
             missing_params = required_freshness.difference(freshness)
             result = "\n- ".join(list(missing_params))  # pragma: no mutate
-            console.print(
-                f"[red]{schema.source_name}.{schema.table_name}[/red]: "
+            print(
+                f"{color_string_red(f'{schema.source_name}.{schema.table_name}')}: "
                 f"miss some required freshness parameters:"
-                f"\n- [yellow]{result}[/yellow] "
+                f"\n- {color_string_yellow(result)} "
             )
     return status_code
 

--- a/pre_commit_dbt/check_source_has_loader.py
+++ b/pre_commit_dbt/check_source_has_loader.py
@@ -5,6 +5,9 @@ from typing import Sequence
 
 from pre_commit_dbt.utils import add_filenames_args
 from pre_commit_dbt.utils import get_source_schemas
+from rich.console import Console
+
+console = Console()
 
 
 def has_loader(paths: Sequence[str]) -> int:
@@ -17,8 +20,8 @@ def has_loader(paths: Sequence[str]) -> int:
     for schema in schemas:
         if not schema.source_schema.get("loader"):
             status_code = 1
-            print(
-                f"{schema.source_name}.{schema.table_name}: "
+            console.print(
+                f"[red]{schema.source_name}.{schema.table_name}[/red]: "
                 f"does not have defined loader.",
             )
     return status_code

--- a/pre_commit_dbt/check_source_has_loader.py
+++ b/pre_commit_dbt/check_source_has_loader.py
@@ -5,9 +5,7 @@ from typing import Sequence
 
 from pre_commit_dbt.utils import add_filenames_args
 from pre_commit_dbt.utils import get_source_schemas
-from rich.console import Console
-
-console = Console()
+from pre_commit_dbt.utils import color_string_red
 
 
 def has_loader(paths: Sequence[str]) -> int:
@@ -20,8 +18,8 @@ def has_loader(paths: Sequence[str]) -> int:
     for schema in schemas:
         if not schema.source_schema.get("loader"):
             status_code = 1
-            console.print(
-                f"[red]{schema.source_name}.{schema.table_name}[/red]: "
+            print(
+                f"{color_string_red(f'{schema.source_name}.{schema.table_name}')}: "
                 f"does not have defined loader.",
             )
     return status_code

--- a/pre_commit_dbt/check_source_has_tests.py
+++ b/pre_commit_dbt/check_source_has_tests.py
@@ -11,9 +11,8 @@ from pre_commit_dbt.utils import get_json
 from pre_commit_dbt.utils import get_parent_childs
 from pre_commit_dbt.utils import get_source_schemas
 from pre_commit_dbt.utils import JsonOpenError
-from rich.console import Console
-
-console = Console()
+from pre_commit_dbt.utils import color_string_red
+from pre_commit_dbt.utils import color_string_yellow
 
 
 def check_test_cnt(
@@ -37,9 +36,9 @@ def check_test_cnt(
         source_test_cnt = len(tests)
         if source_test_cnt < test_cnt:
             status_code = 1
-            console.print(
-                f"[red]{schema.source_name}.{schema.table_name}[/red]: "
-                f"has only [yellow]{source_test_cnt}[/yellow] tests, but [red]{test_cnt}[/red] are required.",
+            print(
+                f"{color_string_red(f'{schema.source_name}.{schema.table_name}')}: "
+                f"has only {color_string_yellow(source_test_cnt)} tests, but {color_string_red(test_cnt)} are required.",
             )
     return status_code
 

--- a/pre_commit_dbt/check_source_has_tests.py
+++ b/pre_commit_dbt/check_source_has_tests.py
@@ -11,6 +11,9 @@ from pre_commit_dbt.utils import get_json
 from pre_commit_dbt.utils import get_parent_childs
 from pre_commit_dbt.utils import get_source_schemas
 from pre_commit_dbt.utils import JsonOpenError
+from rich.console import Console
+
+console = Console()
 
 
 def check_test_cnt(
@@ -34,9 +37,9 @@ def check_test_cnt(
         source_test_cnt = len(tests)
         if source_test_cnt < test_cnt:
             status_code = 1
-            print(
-                f"{schema.source_name}.{schema.table_name}: "
-                f"has only {source_test_cnt} tests, but {test_cnt} are required.",
+            console.print(
+                f"[red]{schema.source_name}.{schema.table_name}[/red]: "
+                f"has only [yellow]{source_test_cnt}[/yellow] tests, but [red]{test_cnt}[/red] are required.",
             )
     return status_code
 

--- a/pre_commit_dbt/check_source_table_has_description.py
+++ b/pre_commit_dbt/check_source_table_has_description.py
@@ -5,6 +5,9 @@ from typing import Sequence
 
 from pre_commit_dbt.utils import add_filenames_args
 from pre_commit_dbt.utils import get_source_schemas
+from rich.console import Console
+
+console = Console()
 
 
 def has_description(paths: Sequence[str]) -> int:
@@ -17,8 +20,8 @@ def has_description(paths: Sequence[str]) -> int:
     for schema in schemas:
         if not schema.table_schema.get("description"):
             status_code = 1
-            print(
-                f"{schema.source_name}.{schema.table_name}: "
+            console.print(
+                f"[red]{schema.source_name}.{schema.table_name}[/red]: "
                 f"does not have defined description.",
             )
     return status_code

--- a/pre_commit_dbt/check_source_table_has_description.py
+++ b/pre_commit_dbt/check_source_table_has_description.py
@@ -5,9 +5,7 @@ from typing import Sequence
 
 from pre_commit_dbt.utils import add_filenames_args
 from pre_commit_dbt.utils import get_source_schemas
-from rich.console import Console
-
-console = Console()
+from pre_commit_dbt.utils import color_string_red
 
 
 def has_description(paths: Sequence[str]) -> int:
@@ -20,8 +18,8 @@ def has_description(paths: Sequence[str]) -> int:
     for schema in schemas:
         if not schema.table_schema.get("description"):
             status_code = 1
-            console.print(
-                f"[red]{schema.source_name}.{schema.table_name}[/red]: "
+            print(
+                f"{color_string_red(f'{schema.source_name}.{schema.table_name}')}: "
                 f"does not have defined description.",
             )
     return status_code

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -469,7 +469,7 @@ def add_related_ymls(
             # Original patch_path has 'project\\path\to\yml.yml'
             patch_path = Path(node["patch_path"])
             # Remove the project_name from patch_path
-            clean_patch_path = patch_path.relative_to(*patch_path.parts[:2])
+            clean_patch_path = patch_path.relative_to(*patch_path.parts[:1])
 
             target_yml_path = f"{root_folder}/{clean_patch_path}"
             if target_yml_path not in paths_with_missing:

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -463,7 +463,7 @@ def add_related_ymls(
         ):
             continue
 
-        if ("path" in node) and (node["path"]) and (node["path"] in sql_path):
+        if ("path" in node) and (node["path"]) and (node.get("path") in sql_path):
             root_folder = Path(node["root_path"]).name
 
             # Original patch_path has 'project\\path\to\yml.yml'
@@ -481,13 +481,11 @@ def get_missing_file_paths(
     manifest: Dict[str, Any] = None,
     include_ephemeral: bool = False,
 ):
-    print(paths)
     nodes = manifest.get("nodes", {})
     paths_with_missing = list(paths)
 
     if nodes:
         for path in paths:
-            print(path)
             suffix = Path(path).suffix.lower()
             if suffix == ".sql":
                 add_related_ymls(path, nodes, paths_with_missing, include_ephemeral)

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -444,7 +444,7 @@ def add_related_sqls(
             and (node["patch_path"])
             and (dbt_patch_path in node["patch_path"])
         ):
-            if ".sql" in node["original_file_path"]:
+            if ".sql" in node["original_file_path"].lower():
                 target_sql_name = f"{root_path}/{node['original_file_path']}"
                 if target_sql_name not in paths_with_missing:
                     paths_with_missing.append(target_sql_name)

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -464,16 +464,18 @@ def add_related_ymls(
             continue
 
         if ("path" in node) and (node["path"]) and (node.get("path") in sql_path):
-            root_folder = Path(node["root_path"]).name
+            patch_path = node.get("patch_path", None)
+            if patch_path:
+                root_folder = Path(node["root_path"]).name
 
-            # Original patch_path has 'project\\path\to\yml.yml'
-            patch_path = Path(node["patch_path"])
-            # Remove the project_name from patch_path
-            clean_patch_path = patch_path.relative_to(*patch_path.parts[:1])
+                # Original patch_path has 'project\\path\to\yml.yml'
+                patch_path = Path(patch_path)
+                # Remove the project_name from patch_path
+                clean_patch_path = patch_path.relative_to(*patch_path.parts[:1])
 
-            target_yml_path = f"{root_folder}/{clean_patch_path}"
-            if target_yml_path not in paths_with_missing:
-                paths_with_missing.append(target_yml_path)
+                target_yml_path = f"{root_folder}/{clean_patch_path}"
+                if target_yml_path not in paths_with_missing:
+                    paths_with_missing.append(target_yml_path)
 
 
 def get_missing_file_paths(

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -494,3 +494,11 @@ def get_missing_file_paths(
                 continue
     print(f"Paths including missing: {','.join(paths_with_missing)}")
     return paths_with_missing
+
+
+def color_string_red(string: str):
+    return "\033[91m" + string + "\033[0m"
+
+
+def color_string_yellow(string: str):
+    return "\033[93m" + string + "\033[0m"

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -428,9 +428,9 @@ def add_related_sqls(
     include_ephemeral: bool = False,
 ):
     yml_path_class = Path(yml_path)
-    yml_path_parts = yml_path_class.parts
+    yml_path_parts = list(yml_path_class.parts)
 
-    root_path = yml_path_parts[0]
+    root_path = yml_path_parts.pop(0)
     dbt_patch_path = "/".join(yml_path_parts)
 
     for key, node in nodes.items():
@@ -439,11 +439,7 @@ def add_related_sqls(
             and node.get("config", {}).get("materialized") == "ephemeral"
         ):
             continue
-        if (
-            ("patch_path" in node)
-            and (node["patch_path"])
-            and (dbt_patch_path in node["patch_path"])
-        ):
+        if node.get("patch_path") and dbt_patch_path in node.get("patch_path"):
             if ".sql" in node["original_file_path"].lower():
                 target_sql_name = f"{root_path}/{node['original_file_path']}"
                 if target_sql_name not in paths_with_missing:
@@ -463,7 +459,7 @@ def add_related_ymls(
         ):
             continue
 
-        if ("path" in node) and (node["path"]) and (node.get("path") in sql_path):
+        if node.get("path") and (node.get("path") in sql_path):
             patch_path = node.get("patch_path", None)
             if patch_path:
                 root_folder = Path(node["root_path"]).name

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -481,11 +481,13 @@ def get_missing_file_paths(
     manifest: Dict[str, Any] = None,
     include_ephemeral: bool = False,
 ):
+    print(paths)
     nodes = manifest.get("nodes", {})
     paths_with_missing = list(paths)
 
     if nodes:
         for path in paths:
+            print(path)
             suffix = Path(path).suffix.lower()
             if suffix == ".sql":
                 add_related_ymls(path, nodes, paths_with_missing, include_ephemeral)

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -481,6 +481,7 @@ def get_missing_file_paths(
     manifest: Dict[str, Any] = None,
     include_ephemeral: bool = False,
 ):
+    print(f"Original paths: {','.join(*paths)}")
     nodes = manifest.get("nodes", {})
     paths_with_missing = list(paths)
 
@@ -493,5 +494,5 @@ def get_missing_file_paths(
                 add_related_sqls(path, nodes, paths_with_missing, include_ephemeral)
             else:
                 continue
-
+    print(f"Paths including missing: {','.join(*paths_with_missing)}")
     return paths_with_missing

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -481,7 +481,7 @@ def get_missing_file_paths(
     manifest: Dict[str, Any] = None,
     include_ephemeral: bool = False,
 ):
-    print(f"Original paths: {','.join(*paths)}")
+    print(f"Original paths: {','.join(paths)}")
     nodes = manifest.get("nodes", {})
     paths_with_missing = list(paths)
 
@@ -494,5 +494,5 @@ def get_missing_file_paths(
                 add_related_sqls(path, nodes, paths_with_missing, include_ephemeral)
             else:
                 continue
-    print(f"Paths including missing: {','.join(*paths_with_missing)}")
+    print(f"Paths including missing: {','.join(paths_with_missing)}")
     return paths_with_missing

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -479,7 +479,6 @@ def get_missing_file_paths(
     manifest: Dict[str, Any] = None,
     include_ephemeral: bool = False,
 ):
-    print(f"Original paths: {','.join(paths)}")
     nodes = manifest.get("nodes", {})
     paths_with_missing = list(paths)
 
@@ -492,7 +491,6 @@ def get_missing_file_paths(
                 add_related_sqls(path, nodes, paths_with_missing, include_ephemeral)
             else:
                 continue
-    print(f"Paths including missing: {','.join(paths_with_missing)}")
     return paths_with_missing
 
 

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -439,7 +439,11 @@ def add_related_sqls(
             and node.get("config", {}).get("materialized") == "ephemeral"
         ):
             continue
-        if (node) and ("patch_path" in node) and (dbt_patch_path in node["patch_path"]):
+        if (
+            ("patch_path" in node)
+            and (node["patch_path"])
+            and (dbt_patch_path in node["patch_path"])
+        ):
             if ".sql" in node["original_file_path"]:
                 target_sql_name = f"{root_path}/{node['original_file_path']}"
                 if target_sql_name not in paths_with_missing:
@@ -459,7 +463,7 @@ def add_related_ymls(
         ):
             continue
 
-        if (node) and ("path" in node) and (node["path"] in sql_path):
+        if ("path" in node) and (node["path"]) and (node["path"] in sql_path):
             root_folder = Path(node["root_path"]).name
 
             # Original patch_path has 'project\\path\to\yml.yml'

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -497,8 +497,8 @@ def get_missing_file_paths(
 
 
 def color_string_red(string: str):
-    return "\033[91m" + string + "\033[0m"
+    return "\033[91m" + str(string) + "\033[0m"
 
 
 def color_string_yellow(string: str):
-    return "\033[93m" + string + "\033[0m"
+    return "\033[93m" + str(string) + "\033[0m"

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -439,7 +439,7 @@ def add_related_sqls(
             and node.get("config", {}).get("materialized") == "ephemeral"
         ):
             continue
-        if "patch_path" in node and dbt_patch_path in node["patch_path"]:
+        if (node) and ("patch_path" in node) and (dbt_patch_path in node["patch_path"]):
             if ".sql" in node["original_file_path"]:
                 target_sql_name = f"{root_path}/{node['original_file_path']}"
                 if target_sql_name not in paths_with_missing:
@@ -459,7 +459,7 @@ def add_related_ymls(
         ):
             continue
 
-        if "path" in node and node["path"] in sql_path:
+        if (node) and ("path" in node) and (node["path"] in sql_path):
             root_folder = Path(node["root_path"]).name
 
             # Original patch_path has 'project\\path\to\yml.yml'

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ classifiers =
 packages = find:
 install_requires =
     pyyaml
-    rich
 python_requires = >=3.7.1
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
 packages = find:
 install_requires =
     pyyaml
+    rich
 python_requires = >=3.7.1
 
 [options.entry_points]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,19 +6,81 @@ from pre_commit_dbt.utils import cmd_output
 
 MANIFEST = {
     "nodes": {
-        "model.with_schema": {"patch_path": "/path/exists"},
-        "model.without_schema": {"patch_path": ""},
-        "model.with_description": {"description": "test description"},
-        "model.without_description": {"description": ""},
-        "model.with_columns": {"columns": {"test": {"name": "test"}}},
-        "model.without_columns": {},
-        "model.with_meta": {"meta": {"foo": "test", "bar": "test"}},
-        "model.with_meta_foo": {"meta": {"foo": "test"}},
-        "model.without_meta": {},
-        "model.with_tags": {"tags": ["foo", "bar"]},
-        "model.with_tags_foo": {"tags": ["foo"]},
-        "model.with_tags_empty": {"tags": []},
-        "model.without_tags": {"database": "prod", "schema": "test"},
+        "model.with_schema": {
+            "patch_path": "project://bb/with_schema.yml",
+            "path": "aa/bb/with_schema.sql",
+            "root_path": "/path/to/aa",
+        },
+        "model.without_schema": {
+            "patch_path": "",
+            "path": "aa/bb/without_schema.sql",
+            "root_path": "/path/to/aa",
+        },
+        "model.with_description": {
+            "description": "test description",
+            "patch_path": "project://bb/with_description.yml",
+            "path": "aa/bb/with_description.sql",
+            "root_path": "/path/to/aa",
+        },
+        "model.without_description": {
+            "description": "",
+            "patch_path": "project://bb/without_description.yml",
+            "path": "aa/bb/without_description.sql",
+            "root_path": "/path/to/aa",
+        },
+        "model.with_columns": {
+            "columns": {"test": {"name": "test"}},
+            "patch_path": "project://bb/with_columns.yml",
+            "path": "aa/bb/with_columns.sql",
+            "root_path": "/path/to/aa",
+        },
+        "model.without_columns": {
+            "patch_path": "project://bb/without_columns.yml",
+            "path": "aa/bb/without_columns.sql",
+            "root_path": "/path/to/aa",
+        },
+        "model.with_meta": {
+            "meta": {"foo": "test", "bar": "test"},
+            "patch_path": "project://bb/with_meta.yml",
+            "path": "aa/bb/with_meta.sql",
+            "root_path": "/path/to/aa",
+        },
+        "model.with_meta_foo": {
+            "meta": {"foo": "test"},
+            "patch_path": "project://bb/with_meta_foo.yml",
+            "path": "aa/bb/with_meta_foo.sql",
+            "root_path": "/path/to/aa",
+        },
+        "model.without_meta": {
+            "patch_path": "project://bb/without_meta.yml",
+            "path": "aa/bb/without_meta.sql",
+            "root_path": "/path/to/aa",
+        },
+        "model.with_tags": {
+            "tags": ["foo", "bar"],
+            "patch_path": "project://bb/with_tags.yml",
+            "path": "aa/bb/with_tags.sql",
+            "root_path": "/path/to/aa",
+        },
+        "model.with_tags_foo": {
+            "tags": ["foo"],
+            "patch_path": "project://bb/with_tags_foo.yml",
+            "path": "aa/bb/with_tags_foo.sql",
+            "root_path": "/path/to/aa",
+        },
+        "model.with_tags_empty": {
+            "tags": [],
+            "patch_path": "project://bb/with_tags_empty.yml",
+            "path": "aa/bb/with_tags_empty.sql",
+            "root_path": "/path/to/aa",
+        },
+        "model.without_tags": {
+            "database": "prod",
+            "schema": "test",
+            "patch_path": "project://bb/without_tags.yml",
+            "path": "aa/bb/without_tags.sql",
+            "root_path": "/path/to/aa",
+        },
         "model.test.catalog_cols": {
             "database": "test",
             "schema": "test",
@@ -28,12 +90,18 @@ MANIFEST = {
                 "col1": {"name": "col1", "description": "test"},
                 "col2": {"name": "col2", "description": "test"},
             },
+            "patch_path": "project://bb/catalog_cols.yml",
+            "path": "aa/bb/catalog_cols.sql",
+            "root_path": "/path/to/aa",
         },
         "model.test.partial_catalog_cols": {
             "name": "partial_catalog_cols",
             "columns": {
                 "col1": {"name": "col1", "description": "test"},
             },
+            "patch_path": "project://bb/partial_catalog_cols.yml",
+            "path": "aa/bb/partial_catalog_cols.sql",
+            "root_path": "/path/to/aa",
         },
         "model.test.only_model_cols": {
             "name": "only_model_cols",
@@ -41,6 +109,9 @@ MANIFEST = {
                 "col1": {"name": "col1", "description": "test"},
                 "col2": {"name": "col2", "description": "test"},
             },
+            "patch_path": "project://bb/only_model_cols.yml",
+            "path": "aa/bb/only_model_cols.sql",
+            "root_path": "/path/to/aa",
         },
         "model.test.without_catalog": {
             "name": "without_catalog",
@@ -51,52 +122,120 @@ MANIFEST = {
                 "col1": {"name": "col1", "description": "test"},
                 "col2": {"name": "col2", "description": "test"},
             },
+            "patch_path": "project://bb/without_catalog.yml",
+            "path": "aa/bb/without_catalog.sql",
+            "root_path": "/path/to/aa",
         },
-        "model.test.only_catalog_cols": {"name": "only_catalog_cols", "columns": {}},
+        "model.test.only_catalog_cols": {
+            "name": "only_catalog_cols",
+            "columns": {},
+            "patch_path": "project://bb/only_catalog_cols.yml",
+            "path": "aa/bb/only_catalog_cols.sql",
+            "root_path": "/path/to/aa",
+        },
         "model.with_column_description": {
             "columns": {
                 "test1": {"name": "test1", "description": "test"},
                 "test2": {"name": "test2", "description": "test"},
-            }
+            },
+            "patch_path": "project://bb/with_column_description.yml",
+            "path": "aa/bb/with_column_description.sql",
+            "root_path": "/path/to/aa",
         },
         "model.with_some_column_description": {
             "columns": {
                 "test1": {"name": "test1", "description": "test"},
                 "test2": {"name": "test2"},
-            }
+            },
+            "patch_path": "project://bb/with_some_column_description.yml",
+            "path": "aa/bb/with_some_column_description.sql",
+            "root_path": "/path/to/aa",
         },
         "model.without_columns_description": {
-            "columns": {"test1": {"name": "test1"}, "test2": {"name": "test2"}}
+            "columns": {
+                "test1": {"name": "test1"},
+                "test2": {"name": "test2"},
+                "patch_path": "project://bb/without_columns_description.yml",
+                "path": "aa/bb/without_columns_description.sql",
+                "root_path": "/path/to/aa",
+            }
         },
         "model.same_col_desc_1": {
             "columns": {
                 "test1": {"name": "test1", "description": "test"},
                 "test2": {"name": "test2", "description": "test"},
-            }
+            },
+            "patch_path": "project://bb/same_col_desc_1.yml",
+            "path": "aa/bb/same_col_desc_1.sql",
+            "root_path": "/path/to/aa",
         },
         "model.same_col_desc_2": {
             "columns": {
                 "test1": {"name": "test1", "description": "test"},
                 "test2": {"name": "test2"},
-            }
+            },
+            "patch_path": "project://bb/same_col_desc_2.yml",
+            "path": "aa/bb/same_col_desc_2.sql",
+            "root_path": "/path/to/aa",
         },
         "model.same_col_desc_3": {
             "columns": {
                 "test1": {"name": "test1", "description": "test1"},
                 "test2": {"name": "test2", "description": "test2"},
-            }
+            },
+            "patch_path": "project://bb/same_col_desc_3.yml",
+            "path": "aa/bb/same_col_desc_3.sql",
+            "root_path": "/path/to/aa",
         },
         "test.test1": {"tags": ["schema"], "test_metadata": {"name": "unique"}},
         "test.test2": {"tags": ["data"]},
         "test.test3": {"tags": ["schema"], "test_metadata": {"name": "unique_where"}},
-        "model.with_test1": {},
-        "model.with_test2": {},
-        "model.with_test3": {},
-        "model.without_test": {},
-        "model.replaced_model": {"alias": "replaced_model"},
-        "model.ref1": {"name": "ref1", "database": "core", "schema": "test"},
-        "model.ref2": {"name": "ref2"},
-        "model.parent_child": {"name": "parent_child"},
+        "model.with_test1": {
+            "patch_path": "project://bb/with_test1.yml",
+            "path": "aa/bb/with_test1.sql",
+            "root_path": "/path/to/aa",
+        },
+        "model.with_test2": {
+            "patch_path": "project://bb/with_test2.yml",
+            "path": "aa/bb/with_test2.sql",
+            "root_path": "/path/to/aa",
+        },
+        "model.with_test3": {
+            "patch_path": "project://bb/with_test3.yml",
+            "path": "aa/bb/with_test3.sql",
+            "root_path": "/path/to/aa",
+        },
+        "model.without_test": {
+            "patch_path": "project://bb/without_test.yml",
+            "path": "aa/bb/without_test.sql",
+            "root_path": "/path/to/aa",
+        },
+        "model.replaced_model": {
+            "alias": "replaced_model",
+            "patch_path": "project://bb/replaced_model.yml",
+            "path": "aa/bb/replaced_model.sql",
+            "root_path": "/path/to/aa",
+        },
+        "model.ref1": {
+            "name": "ref1",
+            "database": "core",
+            "schema": "test",
+            "patch_path": "project://bb/ref1.yml",
+            "path": "aa/bb/ref1.sql",
+            "root_path": "/path/to/aa",
+        },
+        "model.ref2": {
+            "name": "ref2",
+            "patch_path": "project://bb/ref2.yml",
+            "path": "aa/bb/ref2.sql",
+            "root_path": "/path/to/aa",
+        },
+        "model.parent_child": {
+            "name": "parent_child",
+            "patch_path": "project://bb/parent_child.yml",
+            "path": "aa/bb/parent_child.sql",
+            "root_path": "/path/to/aa",
+        },
     },
     "sources": {
         "source.source1.table1": {


### PR DESCRIPTION
FIXES:

- `NoneType object is not suscriptable` reported by @noel: some `nodes` (models in manifest.json) have `"None"` string values in `patch_patch`
- Found an extra error case: some `yml` paths were malformed
- Sanity check: forced lowercasing of node's `original_file_path` when comparing against `.sql` suffix